### PR TITLE
Add React dashboard with optional Streamlit note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# testApp3
+# Competitive Intelligence Dashboard
+
+This project provides a lightweight dashboard for monitoring the latest news and marketing activity of solutions competing with Fredhopper and XO.
+
+The interface is now built in **React** and uses local JSON files located in the `data/` directory. You can update those files with your own observations or integrate a scraper.
+
+## Getting Started
+
+1. Install Node dependencies (used here only for optional future extensions):
+   ```bash
+   npm install
+   ```
+
+2. Serve the static site. One simple way is using Python's built‑in server:
+   ```bash
+   python3 -m http.server 8000
+   ```
+   Then open `http://localhost:8000/index.html` in your browser.
+
+The dashboard exposes three key features:
+
+1. **Latest News Across Competitors** – a list of updates for each solution.
+2. **Latest News for a Specific Competitor** – choose a competitor from the drop‑down to see its news and a summary of the highlighted features.
+3. **Marketing Communication Activity** – a bar chart comparing how frequently each solution communicates in marketing channels.
+
+Feel free to modify or replace the `data/*.json` files to tailor the dashboard to your own research.
+
+### Legacy Streamlit option
+You can still run the original Streamlit interface with:
+```bash
+streamlit run app.py --server.headless true
+```
+This may report a blocked IP check but otherwise serves the same data.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+import json
+import streamlit as st
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# Load data
+with open('data/competitor_news.json') as f:
+    news_data = json.load(f)
+with open('data/marketing_counts.json') as f:
+    marketing_data = json.load(f)
+
+competitors = list(news_data.keys())
+
+st.title('Competitive Intelligence Dashboard')
+
+st.header('Latest News Across Competitors')
+for name, items in news_data.items():
+    st.subheader(name)
+    for item in items:
+        st.write(f"{item['date']} - {item['title']}")
+        st.write(item['summary'])
+
+st.header('Latest News for a Specific Competitor')
+selected = st.selectbox('Choose a competitor', competitors)
+
+if selected:
+    st.subheader(f'News for {selected}')
+    entries = news_data.get(selected, [])
+    summaries = []
+    for item in entries:
+        st.write(f"{item['date']} - {item['title']}")
+        st.write(item['summary'])
+        summaries.append(item['summary'])
+    if summaries:
+        st.markdown('**Summary of highlighted features:**')
+        for s in summaries:
+            st.write('-', s)
+
+st.header('Marketing Communication Activity')
+fig, ax = plt.subplots()
+keys = list(marketing_data.keys())
+values = [marketing_data[k] for k in keys]
+ax.bar(keys, values, color='skyblue')
+ax.set_xlabel('Solution')
+ax.set_ylabel('Number of marketing communications')
+ax.set_title('Marketing Activity')
+st.pyplot(fig)
+

--- a/data/competitor_news.json
+++ b/data/competitor_news.json
@@ -1,0 +1,35 @@
+{
+  "Algolia": [
+    {
+      "date": "2025-06-15",
+      "title": "Algolia new AI search features",
+      "summary": "Algolia launched an AI-driven search algorithm that boosts relevancy."
+    },
+    {
+      "date": "2025-06-01",
+      "title": "Algolia integrates with Shopify",
+      "summary": "New integration plugin for Shopify to help e-commerce stores."
+    }
+  ],
+  "Bloomreach": [
+    {
+      "date": "2025-06-10",
+      "title": "Bloomreach Content update 3.5",
+      "summary": "The update includes advanced personalization features."
+    }
+  ],
+  "Fredhopper": [
+    {
+      "date": "2025-06-05",
+      "title": "Fredhopper release 2.1",
+      "summary": "Improvements to search algorithms and new analytics dashboard."
+    }
+  ],
+  "XO": [
+    {
+      "date": "2025-05-20",
+      "title": "XO cross-channel personalization",
+      "summary": "Introduction of new machine learning models for recommendations."
+    }
+  ]
+}

--- a/data/marketing_counts.json
+++ b/data/marketing_counts.json
@@ -1,0 +1,6 @@
+{
+  "Algolia": 40,
+  "Bloomreach": 30,
+  "Fredhopper": 20,
+  "XO": 15
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Competitive Intelligence Dashboard</title>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    h1, h2 { color: #333; }
+    select { margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="src/app.jsx"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "testapp3",
+  "version": "1.0.0",
+  "description": "This small Streamlit app provides a way to browse recent news about search and recommendation solutions that compete with Fredhopper and XO. Due to the environment having no internet access, the app uses static example data stored in JSON files. You can modify the `data` directory to include your own observations or integrate your own scraper.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "chart.js": "^4.5.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+matplotlib
+pandas

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,0 +1,81 @@
+function App() {
+  const [newsData, setNewsData] = React.useState({});
+  const [marketingData, setMarketingData] = React.useState({});
+  const [selected, setSelected] = React.useState('');
+
+  React.useEffect(() => {
+    fetch('data/competitor_news.json').then(r => r.json()).then(setNewsData);
+    fetch('data/marketing_counts.json').then(r => r.json()).then(setMarketingData);
+  }, []);
+
+  React.useEffect(() => {
+    if (Object.keys(marketingData).length) {
+      const ctx = document.getElementById('chart').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: Object.keys(marketingData),
+          datasets: [{
+            label: 'Marketing communications',
+            data: Object.values(marketingData),
+            backgroundColor: 'skyblue'
+          }]
+        },
+        options: {
+          responsive: true,
+          plugins: { legend: { display: false } }
+        }
+      });
+    }
+  }, [marketingData]);
+
+  const competitors = Object.keys(newsData);
+  const selectedNews = selected ? (newsData[selected] || []) : [];
+  const featureSummaries = selectedNews.map(item => item.summary);
+
+  return (
+    <div>
+      <h1>Competitive Intelligence Dashboard</h1>
+
+      <h2>Latest News Across Competitors</h2>
+      {competitors.map(name => (
+        <div key={name}>
+          <h3>{name}</h3>
+          {(newsData[name] || []).map((item, i) => (
+            <div key={i}>
+              <strong>{item.date} - {item.title}</strong>
+              <p>{item.summary}</p>
+            </div>
+          ))}
+        </div>
+      ))}
+
+      <h2>Latest News for a Specific Competitor</h2>
+      <select value={selected} onChange={e => setSelected(e.target.value)}>
+        <option value="">-- choose --</option>
+        {competitors.map(name => <option key={name} value={name}>{name}</option>)}
+      </select>
+
+      {selected && (
+        <div>
+          <h3>News for {selected}</h3>
+          {selectedNews.map((item, i) => (
+            <div key={i}>
+              <strong>{item.date} - {item.title}</strong>
+              <p>{item.summary}</p>
+            </div>
+          ))}
+          <h4>Summary of highlighted features:</h4>
+          <ul>
+            {featureSummaries.map((s, i) => <li key={i}>{s}</li>)}
+          </ul>
+        </div>
+      )}
+
+      <h2>Marketing Communication Activity</h2>
+      <canvas id="chart"></canvas>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary
- switch from Streamlit to a small React UI
- serve static JSON data and draw marketing chart with Chart.js
- update README with instructions for running the React interface
- mention how to launch the legacy Streamlit version
- add package.json and ignore node_modules

## Testing
- `python -m py_compile app.py`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_685329af013883208cbbbcbb9a540a67