### PR TITLE
Merge news sections with competitor filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+data.db

--- a/README.md
+++ b/README.md
@@ -2,26 +2,35 @@
 
 This project provides a lightweight dashboard for monitoring the latest news and marketing activity of solutions competing with Fredhopper and XO.
 
-The interface is now built in **React** and uses local JSON files located in the `data/` directory. You can update those files with your own observations or integrate a scraper.
+The interface is built in **React** and now relies on a small Flask API that
+serves data from an SQLite database. Sample JSON files in the `data/` directory
+can be imported into the database so the dashboard updates dynamically.
 
 ## Getting Started
 
-1. Install Node dependencies (used here only for optional future extensions):
+1. Install Python requirements and optional Node dependencies:
    ```bash
+   pip install -r requirements.txt
    npm install
    ```
 
-2. Serve the static site. One simple way is using Python's built‑in server:
+2. Initialize the SQLite database and start the API server:
+   ```bash
+   python db_setup.py       # populate data.db from JSON files
+   python api.py            # start Flask on http://localhost:5000
+   ```
+
+3. Serve the static site. One simple way is using Python's built‑in server:
    ```bash
    python3 -m http.server 8000
    ```
    Then open `http://localhost:8000/index.html` in your browser.
+   The page expects the API to be reachable at `http://localhost:5000`.
 
-The dashboard exposes three key features:
+The dashboard exposes two key features:
 
-1. **Latest News Across Competitors** – a list of updates for each solution.
-2. **Latest News for a Specific Competitor** – choose a competitor from the drop‑down to see its news and a summary of the highlighted features.
-3. **Marketing Communication Activity** – a bar chart comparing how frequently each solution communicates in marketing channels.
+1. **Latest News** – view updates across all competitors or filter the list to a single solution. When a competitor is selected, a summary of the highlighted features is shown.
+2. **Marketing Communication Activity** – a bar chart comparing how frequently each solution communicates in marketing channels.
 
 Feel free to modify or replace the `data/*.json` files to tailor the dashboard to your own research.
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,54 @@
+from flask import Flask, jsonify
+from flask_cors import CORS
+import sqlite3
+
+app = Flask(__name__)
+CORS(app)
+
+def get_db_connection():
+    conn = sqlite3.connect('data.db')
+    conn.row_factory = sqlite3.Row
+    return conn
+
+@app.route('/api/news')
+def all_news():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute('SELECT competitor, date, title, summary FROM competitor_news')
+    rows = cur.fetchall()
+    conn.close()
+    data = {}
+    for row in rows:
+        data.setdefault(row['competitor'], []).append({
+            'date': row['date'],
+            'title': row['title'],
+            'summary': row['summary']
+        })
+    return jsonify(data)
+
+@app.route('/api/news/<competitor>')
+def news_for_competitor(competitor):
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute('SELECT date, title, summary FROM competitor_news WHERE competitor=?', (competitor,))
+    rows = cur.fetchall()
+    conn.close()
+    data = [{
+        'date': row['date'],
+        'title': row['title'],
+        'summary': row['summary']
+    } for row in rows]
+    return jsonify(data)
+
+@app.route('/api/marketing')
+def marketing_counts():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute('SELECT competitor, count FROM marketing_counts')
+    rows = cur.fetchall()
+    conn.close()
+    data = {row['competitor']: row['count'] for row in rows}
+    return jsonify(data)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -13,24 +13,22 @@ competitors = list(news_data.keys())
 
 st.title('Competitive Intelligence Dashboard')
 
-st.header('Latest News Across Competitors')
-for name, items in news_data.items():
+st.header('Latest News')
+selected = st.selectbox('Filter by competitor', ['All'] + competitors)
+
+def show_news(name, items):
     st.subheader(name)
     for item in items:
         st.write(f"{item['date']} - {item['title']}")
         st.write(item['summary'])
 
-st.header('Latest News for a Specific Competitor')
-selected = st.selectbox('Choose a competitor', competitors)
-
-if selected:
-    st.subheader(f'News for {selected}')
+if selected == 'All':
+    for name, items in news_data.items():
+        show_news(name, items)
+else:
     entries = news_data.get(selected, [])
-    summaries = []
-    for item in entries:
-        st.write(f"{item['date']} - {item['title']}")
-        st.write(item['summary'])
-        summaries.append(item['summary'])
+    show_news(selected, entries)
+    summaries = [item['summary'] for item in entries]
     if summaries:
         st.markdown('**Summary of highlighted features:**')
         for s in summaries:

--- a/db_setup.py
+++ b/db_setup.py
@@ -1,0 +1,44 @@
+import json
+import sqlite3
+
+def init_db(db_path='data.db'):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+
+    c.execute('DROP TABLE IF EXISTS competitor_news')
+    c.execute('DROP TABLE IF EXISTS marketing_counts')
+
+    c.execute('''CREATE TABLE competitor_news (
+                    competitor TEXT,
+                    date TEXT,
+                    title TEXT,
+                    summary TEXT
+                )''')
+    c.execute('''CREATE TABLE marketing_counts (
+                    competitor TEXT PRIMARY KEY,
+                    count INTEGER
+                )''')
+
+    with open('data/competitor_news.json') as f:
+        news_data = json.load(f)
+    for comp, items in news_data.items():
+        for item in items:
+            c.execute(
+                'INSERT INTO competitor_news (competitor, date, title, summary) VALUES (?, ?, ?, ?)',
+                (comp, item['date'], item['title'], item['summary'])
+            )
+
+    with open('data/marketing_counts.json') as f:
+        marketing_data = json.load(f)
+    for comp, count in marketing_data.items():
+        c.execute(
+            'INSERT INTO marketing_counts (competitor, count) VALUES (?, ?)',
+            (comp, count)
+        )
+
+    conn.commit()
+    conn.close()
+
+if __name__ == '__main__':
+    init_db()
+    print('Database initialized')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 streamlit
 matplotlib
 pandas
+
+flask
+sqlalchemy
+flask-cors

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,11 +1,11 @@
 function App() {
   const [newsData, setNewsData] = React.useState({});
   const [marketingData, setMarketingData] = React.useState({});
-  const [selected, setSelected] = React.useState('');
+  const [filter, setFilter] = React.useState('All');
 
   React.useEffect(() => {
-    fetch('data/competitor_news.json').then(r => r.json()).then(setNewsData);
-    fetch('data/marketing_counts.json').then(r => r.json()).then(setMarketingData);
+    fetch('/api/news').then(r => r.json()).then(setNewsData);
+    fetch('/api/marketing').then(r => r.json()).then(setMarketingData);
   }, []);
 
   React.useEffect(() => {
@@ -30,15 +30,20 @@ function App() {
   }, [marketingData]);
 
   const competitors = Object.keys(newsData);
-  const selectedNews = selected ? (newsData[selected] || []) : [];
+  const selectedNews = filter !== 'All' ? (newsData[filter] || []) : [];
   const featureSummaries = selectedNews.map(item => item.summary);
 
   return (
     <div>
       <h1>Competitive Intelligence Dashboard</h1>
 
-      <h2>Latest News Across Competitors</h2>
-      {competitors.map(name => (
+      <h2>Latest News</h2>
+      <select value={filter} onChange={e => setFilter(e.target.value)}>
+        <option value="All">All</option>
+        {competitors.map(name => <option key={name} value={name}>{name}</option>)}
+      </select>
+
+      {(filter === 'All' ? competitors : [filter]).map(name => (
         <div key={name}>
           <h3>{name}</h3>
           {(newsData[name] || []).map((item, i) => (
@@ -50,21 +55,8 @@ function App() {
         </div>
       ))}
 
-      <h2>Latest News for a Specific Competitor</h2>
-      <select value={selected} onChange={e => setSelected(e.target.value)}>
-        <option value="">-- choose --</option>
-        {competitors.map(name => <option key={name} value={name}>{name}</option>)}
-      </select>
-
-      {selected && (
+      {filter !== 'All' && selectedNews.length > 0 && (
         <div>
-          <h3>News for {selected}</h3>
-          {selectedNews.map((item, i) => (
-            <div key={i}>
-              <strong>{item.date} - {item.title}</strong>
-              <p>{item.summary}</p>
-            </div>
-          ))}
           <h4>Summary of highlighted features:</h4>
           <ul>
             {featureSummaries.map((s, i) => <li key={i}>{s}</li>)}


### PR DESCRIPTION
## Summary
- merge the "Latest News" sections together
- show a single filter dropdown for choosing a competitor or "All"
- update Streamlit app accordingly
- document the simplified features in README
- bring over Flask API and DB setup from main

## Testing
- `npm install --ignore-scripts --no-audit`
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6853317d70008320889f87c01acc0ef9