### PR TITLE
Add competitor management

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The dashboard exposes two key features:
 1. **Latest News** – view updates across all competitors or filter the list to a single solution. When a competitor is selected, a summary of the highlighted features is shown.
 2. **Marketing Communication Activity** – a bar chart comparing how frequently each solution communicates in marketing channels.
 
+The API also exposes basic endpoints to manage the list of competitors. Use `/api/competitors` (GET/POST) and `/api/competitors/<name>` (GET/PUT/DELETE) to add or update solutions along with a link to their marketing page. The front-end now lists these competitors and lets you add new ones.
+
 Feel free to modify or replace the `data/*.json` files to tailor the dashboard to your own research.
 
 ### Legacy Streamlit option

--- a/api.py
+++ b/api.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request, abort
 from flask_cors import CORS
 import sqlite3
 
@@ -49,6 +49,65 @@ def marketing_counts():
     conn.close()
     data = {row['competitor']: row['count'] for row in rows}
     return jsonify(data)
+
+@app.route('/api/competitors', methods=['GET', 'POST'])
+def competitors():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    if request.method == 'POST':
+        data = request.get_json(force=True)
+        name = data.get('name')
+        url = data.get('marketing_url')
+        if not name or not url:
+            conn.close()
+            return jsonify({'error': 'name and marketing_url required'}), 400
+        try:
+            cur.execute('INSERT INTO competitors (name, marketing_url) VALUES (?, ?)', (name, url))
+            conn.commit()
+        except sqlite3.IntegrityError:
+            conn.close()
+            return jsonify({'error': 'competitor exists'}), 400
+        conn.close()
+        return jsonify({'status': 'ok'}), 201
+    else:
+        cur.execute('SELECT name, marketing_url FROM competitors')
+        rows = cur.fetchall()
+        conn.close()
+        data = [{'name': r['name'], 'marketing_url': r['marketing_url']} for r in rows]
+        return jsonify(data)
+
+@app.route('/api/competitors/<name>', methods=['GET', 'PUT', 'DELETE'])
+def competitor_detail(name):
+    conn = get_db_connection()
+    cur = conn.cursor()
+    if request.method == 'GET':
+        cur.execute('SELECT name, marketing_url FROM competitors WHERE name=?', (name,))
+        row = cur.fetchone()
+        conn.close()
+        if row is None:
+            abort(404)
+        return jsonify({'name': row['name'], 'marketing_url': row['marketing_url']})
+    elif request.method == 'PUT':
+        data = request.get_json(force=True)
+        url = data.get('marketing_url')
+        if not url:
+            conn.close()
+            return jsonify({'error': 'marketing_url required'}), 400
+        cur.execute('UPDATE competitors SET marketing_url=? WHERE name=?', (url, name))
+        if cur.rowcount == 0:
+            conn.close()
+            abort(404)
+        conn.commit()
+        conn.close()
+        return jsonify({'status': 'ok'})
+    else:  # DELETE
+        cur.execute('DELETE FROM competitors WHERE name=?', (name,))
+        if cur.rowcount == 0:
+            conn.close()
+            abort(404)
+        conn.commit()
+        conn.close()
+        return jsonify({'status': 'deleted'})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/data/competitors.json
+++ b/data/competitors.json
@@ -1,0 +1,6 @@
+{
+  "Algolia": "https://www.algolia.com",
+  "Bloomreach": "https://www.bloomreach.com",
+  "Fredhopper": "https://www.fredhopper.com",
+  "XO": "https://www.xo.com"
+}

--- a/db_setup.py
+++ b/db_setup.py
@@ -5,9 +5,14 @@ def init_db(db_path='data.db'):
     conn = sqlite3.connect(db_path)
     c = conn.cursor()
 
+    c.execute('DROP TABLE IF EXISTS competitors')
     c.execute('DROP TABLE IF EXISTS competitor_news')
     c.execute('DROP TABLE IF EXISTS marketing_counts')
 
+    c.execute('''CREATE TABLE competitors (
+                    name TEXT PRIMARY KEY,
+                    marketing_url TEXT
+                )''')
     c.execute('''CREATE TABLE competitor_news (
                     competitor TEXT,
                     date TEXT,
@@ -18,6 +23,14 @@ def init_db(db_path='data.db'):
                     competitor TEXT PRIMARY KEY,
                     count INTEGER
                 )''')
+
+    with open('data/competitors.json') as f:
+        comp_data = json.load(f)
+    for name, url in comp_data.items():
+        c.execute(
+            'INSERT INTO competitors (name, marketing_url) VALUES (?, ?)',
+            (name, url)
+        )
 
     with open('data/competitor_news.json') as f:
         news_data = json.load(f)

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,11 +1,15 @@
 function App() {
   const [newsData, setNewsData] = React.useState({});
   const [marketingData, setMarketingData] = React.useState({});
+  const [competitorsList, setCompetitorsList] = React.useState([]);
+  const [newName, setNewName] = React.useState('');
+  const [newUrl, setNewUrl] = React.useState('');
   const [filter, setFilter] = React.useState('All');
 
   React.useEffect(() => {
     fetch('/api/news').then(r => r.json()).then(setNewsData);
     fetch('/api/marketing').then(r => r.json()).then(setMarketingData);
+    fetch('/api/competitors').then(r => r.json()).then(setCompetitorsList);
   }, []);
 
   React.useEffect(() => {
@@ -33,9 +37,39 @@ function App() {
   const selectedNews = filter !== 'All' ? (newsData[filter] || []) : [];
   const featureSummaries = selectedNews.map(item => item.summary);
 
+  function addCompetitor(e) {
+    e.preventDefault();
+    fetch('/api/competitors', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName, marketing_url: newUrl })
+    }).then(r => {
+      if (r.ok) {
+        setCompetitorsList([...competitorsList, { name: newName, marketing_url: newUrl }]);
+        setNewName('');
+        setNewUrl('');
+      }
+    });
+  }
+
   return (
     <div>
       <h1>Competitive Intelligence Dashboard</h1>
+
+      <h2>Competitors</h2>
+      <ul>
+        {competitorsList.map(c => (
+          <li key={c.name}>
+            <a href={c.marketing_url} target="_blank">{c.name}</a>
+          </li>
+        ))}
+      </ul>
+
+      <form onSubmit={addCompetitor} style={{ marginBottom: '20px' }}>
+        <input value={newName} onChange={e => setNewName(e.target.value)} placeholder="Name" required />
+        <input value={newUrl} onChange={e => setNewUrl(e.target.value)} placeholder="Marketing URL" required />
+        <button type="submit">Add</button>
+      </form>
 
       <h2>Latest News</h2>
       <select value={filter} onChange={e => setFilter(e.target.value)}>


### PR DESCRIPTION
## Summary
- add `competitors.json` seed data
- extend the database initializer with a `competitors` table
- implement `/api/competitors` API for CRUD operations
- display and manage competitors from the React UI
- document competitor management endpoints in README

## Testing
- `python db_setup.py`
- `python -m py_compile api.py db_setup.py`
- `npx --yes babel src/app.jsx --out-file compiled.js`
- `FLASK_APP=api.py flask run -p 5051 >/tmp/api.log 2>&1 &` *(server started for curl test)*
- `curl -s http://127.0.0.1:5051/api/competitors`

------
https://chatgpt.com/codex/tasks/task_e_685335eef1fc8320a7789ea7190147f5